### PR TITLE
Fix #10 and handle closed requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,11 @@ TransformerStream.prototype.write = function (data) {
   this.chunks.push(data);
 };
 
-TransformerStream.prototype.end = function () {
+TransformerStream.prototype.end = function (data) {
+  if (data) {
+    this.chunks.push(data);
+  }
+  
   var self = this;
   var emit = function(data) {
     self.emit('data', data);


### PR DESCRIPTION
This adds a small fix for #10 but more importantly it handles closed requests and prevents attempting to call transformer functions with bad or no data(without anyway for the transformer to see if it is bad).